### PR TITLE
Add volume for postgres database to example

### DIFF
--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -4,6 +4,8 @@ services:
   db:
     image: postgres:${POSTGRES_VERSION}
     container_name: spliit_db
+    volumes:
+      - database:/var/lib/postgresql/data
     environment:
       - "TZ"
       - "POSTGRES_DB"
@@ -28,3 +30,6 @@ services:
       - "POSTGRES_USER"
       - "POSTGRES_PASSWORD"
     restart: always
+
+volumes:
+  database


### PR DESCRIPTION
Hi,
The example doesn't mention creating a volume for the postgres db. I added the lines to the docker-compose. This way state is preserved in a volume.